### PR TITLE
Project keepers by bfbValue when not set in Sleeper for mock draft

### DIFF
--- a/src/api/bfbApi.js
+++ b/src/api/bfbApi.js
@@ -144,6 +144,46 @@ export const selectKeepers = createSelector(
   },
 );
 
+// Returns the effective keeper set for each roster:
+// - uses actual Sleeper keepers if set for that roster
+// - falls back to projecting top-8 players by bfbValue when not set
+const _getEffectiveKeeperIds = (rosters, players, leagueType) => {
+  let key = leagueType === 2 ? "players" : "keepers";
+  return rosters.flatMap((roster) => {
+    let setKeepers = roster[key] ?? [];
+    if (setKeepers.length > 0) return setKeepers;
+    // No keepers set in Sleeper — project top 8 by bfbValue
+    return (roster.players ?? [])
+      .map((pId) => find(players, { id: pId }))
+      .filter((p) => p?.full_name)
+      .sort((a, b) => (b.bfbValue ?? 0) - (a.bfbValue ?? 0))
+      .slice(0, 8)
+      .map((p) => p.id);
+  });
+};
+
+export const selectEffectiveKeepers = createSelector(
+  (state, rawData) => rawData,
+  (rawData) => {
+    let { rosters, players, leagueType } = rawData;
+    if (!rosters || !players || players.length === 0 || rosters.length === 0)
+      return [];
+    let keeperIds = _getEffectiveKeeperIds(rosters, players, leagueType);
+    return players.filter((p) => keeperIds.includes(p.id));
+  },
+);
+
+export const selectEffectiveNonKeepers = createSelector(
+  (state, rawData) => rawData,
+  (rawData) => {
+    let { rosters, players, leagueType } = rawData;
+    if (!rosters || !players || players.length === 0 || rosters.length === 0)
+      return [];
+    let keeperIds = new Set(_getEffectiveKeeperIds(rosters, players, leagueType));
+    return players.filter((p) => !keeperIds.has(p.id));
+  },
+);
+
 export const selectPlayersProjectedKeepers = createSelector(
   (state, rawData) => rawData,
   (data) => {

--- a/src/pages/mock/mocks-new.jsx
+++ b/src/pages/mock/mocks-new.jsx
@@ -30,8 +30,8 @@ import {
   setFullDraft,
 } from "../../api/draftSlice";
 import {
-  selectNonKeepers,
-  selectKeepers,
+  selectEffectiveKeepers,
+  selectEffectiveNonKeepers,
   useGetMockQuery,
   useGetMocksQuery,
   usePostMockMutation,
@@ -104,7 +104,7 @@ const MockNew = () => {
   const leagueId = useSelector(selectLeagueId);
   let current = find(seasons, { league_id: leagueId });
   const keepers = useSelector((state) =>
-    selectKeepers(state, {
+    selectEffectiveKeepers(state, {
       rosters: data,
       players: playersAll,
       leagueType: current?.settings?.type,
@@ -112,9 +112,10 @@ const MockNew = () => {
   );
 
   const nonKeepers = useSelector((state) =>
-    selectNonKeepers(state, {
+    selectEffectiveNonKeepers(state, {
       rosters: data,
       players: playersAll,
+      leagueType: current?.settings?.type,
     }),
   );
   let availablePlayers = nonKeepers

--- a/src/pages/mock/useActiveRoster.js
+++ b/src/pages/mock/useActiveRoster.js
@@ -1,7 +1,7 @@
 import find from "lodash/find";
 import { useSelector } from "react-redux";
 import { useGetRostersQuery } from "../../api/api";
-import { useGetPlayersQuery } from "../../api/bfbApi";
+import { useGetPlayersQuery, useGetPlayersAllQuery } from "../../api/bfbApi";
 import { selectActiveSlot, selectDraftedPlayers } from "../../api/draftSlice";
 import {
   selectLeagueId,
@@ -19,12 +19,32 @@ const useActiveRoster = () => {
   const { data: playerIdsData, isFetching: isRosterFetching } =
     useGetRostersQuery();
   let keeperKey = current?.settings?.type === 2 ? "players" : "keepers";
-  let playerIds = find(playerIdsData, {
+  let activeRosterData = find(playerIdsData, {
     roster_id: activeSlot.roster_id,
-  })?.[keeperKey];
+  });
+  let playerIds = activeRosterData?.[keeperKey];
+
+  // Fetch playersAll only when needed to project keepers (no Sleeper keepers set)
+  const hasSleeperKeepers = !!(playerIds && playerIds.length);
+  const { data: playersAll } = useGetPlayersAllQuery(
+    { year, mock: true },
+    { skip: hasSleeperKeepers || isRosterFetching || !activeRosterData }
+  );
+
+  // When no keepers are set in Sleeper, project top 8 by bfbValue
+  let effectivePlayerIds = playerIds;
+  if (!hasSleeperKeepers && playersAll && activeRosterData?.players) {
+    effectivePlayerIds = activeRosterData.players
+      .map((pId) => find(playersAll, { id: pId }))
+      .filter((p) => p?.full_name)
+      .sort((a, b) => (b.bfbValue ?? 0) - (a.bfbValue ?? 0))
+      .slice(0, 8)
+      .map((p) => p.id);
+  }
+
   const { data, isFetching: isPlayerFetching } = useGetPlayersQuery(
-    { id: JSON.stringify(playerIds), year: year - 1 },
-    { skip: !playerIds || !playerIds.length || isRosterFetching }
+    { id: JSON.stringify(effectivePlayerIds), year: year - 1 },
+    { skip: !effectivePlayerIds || !effectivePlayerIds.length || isRosterFetching }
   );
 
   let players = data ? data.map((p) => ({ ...p, isKeeper: true })) : [];


### PR DESCRIPTION
When a team hasn't set their keepers in Sleeper, draft keepers are now
projected by picking the top-8 players on their roster ranked by bfbValue.
These projected keepers are hidden from the available player board and shown
in the team's roster tab (marked "Kept") just like actual Sleeper keepers.

- Add selectEffectiveKeepers / selectEffectiveNonKeepers selectors in bfbApi.js
  that per-roster fall back to bfbValue projection when keepers field is empty
- Update mocks-new.jsx to use the new selectors (replaces selectKeepers /
  selectNonKeepers) so the available board excludes projected keepers
- Update useActiveRoster.js to fetch playersAll and compute projected keeper
  IDs when no Sleeper keepers exist, so the roster tab shows them correctly

https://claude.ai/code/session_01CC5XbG3gCtkSPAaaj9quEq